### PR TITLE
feat: Law 명령어 구현 (#7)

### DIFF
--- a/internal/cmd/law.go
+++ b/internal/cmd/law.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pyhub-kr/pyhub-sejong-cli/internal/api"
+	"github.com/pyhub-kr/pyhub-sejong-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	outputFormat string
+	pageNo       int
+	pageSize     int
+)
+
+// lawCmd represents the law command
+var lawCmd = &cobra.Command{
+	Use:   "law <검색어>",
+	Short: "법령 정보 검색",
+	Long: `국가법령정보센터에서 법령 정보를 검색합니다.
+
+검색어를 입력하면 관련 법령들의 목록을 확인할 수 있습니다.
+기본적으로 테이블 형식으로 출력되며, --format 옵션으로 JSON 형식도 지원합니다.`,
+	Example: `  # 기본 검색
+  sejong law "개인정보 보호법"
+  
+  # JSON 형식으로 출력
+  sejong law "도로교통법" --format json
+  
+  # 페이지네이션 옵션
+  sejong law "민법" --page 2 --size 20`,
+	Args: cobra.ExactArgs(1),
+	RunE: runLawCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(lawCmd)
+	
+	// Flags
+	lawCmd.Flags().StringVarP(&outputFormat, "format", "f", "table", "출력 형식 (table, json)")
+	lawCmd.Flags().IntVarP(&pageNo, "page", "p", 1, "페이지 번호")
+	lawCmd.Flags().IntVarP(&pageSize, "size", "s", 10, "페이지 크기")
+}
+
+func runLawCommand(cmd *cobra.Command, args []string) error {
+	// Get search query
+	query := strings.TrimSpace(args[0])
+	if query == "" {
+		return fmt.Errorf("검색어를 입력해주세요")
+	}
+	
+	// Create API client
+	client, err := api.NewClient()
+	if err != nil {
+		// Check if it's an API key error
+		if strings.Contains(err.Error(), "API 키") {
+			fmt.Fprintln(os.Stderr, "❌ API 키가 설정되지 않았습니다.")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "국가법령정보센터 오픈 API 이용을 위해 인증키가 필요합니다.")
+			fmt.Fprintln(os.Stderr, "1. 인증키 발급: https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9")
+			fmt.Fprintln(os.Stderr, "2. 키 설정: sejong config set law.key <발급받은_인증키>")
+			return nil // Return nil to avoid printing the error twice
+		}
+		return fmt.Errorf("API 클라이언트 생성 실패: %w", err)
+	}
+	
+	// Show searching message
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	if verbose {
+		fmt.Fprintf(os.Stderr, "검색 중... (%s)\n", query)
+	}
+	
+	// Create search request
+	req := &api.SearchRequest{
+		Query:    query,
+		Type:     api.TypeJSON,
+		PageNo:   pageNo,
+		PageSize: pageSize,
+	}
+	
+	// Search with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	
+	resp, err := client.Search(ctx, req)
+	if err != nil {
+		return fmt.Errorf("검색 실패: %w", err)
+	}
+	
+	// Output results
+	formatter := output.NewFormatter(outputFormat)
+	if err := formatter.FormatSearchResult(resp); err != nil {
+		return fmt.Errorf("출력 실패: %w", err)
+	}
+	
+	return nil
+}

--- a/internal/cmd/law_test.go
+++ b/internal/cmd/law_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestLawCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "No arguments",
+			args:        []string{},
+			wantErr:     true,
+			errContains: "accepts 1 arg(s), received 0",
+		},
+		{
+			name:        "Empty search query",
+			args:        []string{""},
+			wantErr:     true,
+			errContains: "검색어를 입력해주세요",
+		},
+		{
+			name:        "Multiple arguments",
+			args:        []string{"arg1", "arg2"},
+			wantErr:     true,
+			errContains: "accepts 1 arg(s), received 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new root command for testing
+			cmd := &cobra.Command{Use: "test"}
+			cmd.AddCommand(lawCmd)
+
+			// Set args
+			args := append([]string{"law"}, tt.args...)
+			cmd.SetArgs(args)
+
+			// Capture output
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+
+			// Execute command
+			err := cmd.Execute()
+
+			// Check error
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Error should contain %q, got %q", tt.errContains, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestLawCommandFlags(t *testing.T) {
+	// Test that flags are properly registered
+	if lawCmd.Flag("format") == nil {
+		t.Error("format flag not registered")
+	}
+	if lawCmd.Flag("page") == nil {
+		t.Error("page flag not registered")
+	}
+	if lawCmd.Flag("size") == nil {
+		t.Error("size flag not registered")
+	}
+
+	// Test default values
+	formatFlag := lawCmd.Flag("format")
+	if formatFlag.DefValue != "table" {
+		t.Errorf("format flag default = %s, want table", formatFlag.DefValue)
+	}
+
+	pageFlag := lawCmd.Flag("page")
+	if pageFlag.DefValue != "1" {
+		t.Errorf("page flag default = %s, want 1", pageFlag.DefValue)
+	}
+
+	sizeFlag := lawCmd.Flag("size")
+	if sizeFlag.DefValue != "10" {
+		t.Errorf("size flag default = %s, want 10", sizeFlag.DefValue)
+	}
+}

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -77,7 +77,12 @@ func (f *Formatter) formatTable(resp *api.SearchResponse) error {
 	// Show pagination info if there are more results
 	if resp.TotalCount > len(resp.Laws) {
 		currentPage := resp.Page
-		totalPages := (resp.TotalCount + len(resp.Laws) - 1) / len(resp.Laws)
+		// Use a default page size of 10 if not enough items to determine
+		pageSize := 10
+		if len(resp.Laws) > 0 {
+			pageSize = len(resp.Laws)
+		}
+		totalPages := (resp.TotalCount + pageSize - 1) / pageSize
 		fmt.Printf("\n페이지 %d/%d (--page 옵션으로 다른 페이지 조회 가능)\n", currentPage, totalPages)
 	}
 	
@@ -94,13 +99,21 @@ func formatDate(date string) string {
 
 // truncateString truncates a string to maxLen and adds ellipsis if needed
 func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
+	if maxLen <= 0 {
+		return ""
 	}
-	// Handle Korean characters properly by using rune slice
+	
+	// Handle Unicode characters properly by using rune slice
 	runes := []rune(s)
 	if len(runes) <= maxLen {
 		return s
 	}
+	
+	// Ensure we don't underflow when adding ellipsis
+	if maxLen <= 3 {
+		// Return just ellipsis dots up to maxLen
+		return "..."[:maxLen]
+	}
+	
 	return string(runes[:maxLen-3]) + "..."
 }

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -1,0 +1,106 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pyhub-kr/pyhub-sejong-cli/internal/api"
+)
+
+// Formatter handles output formatting
+type Formatter struct {
+	format string
+}
+
+// NewFormatter creates a new formatter with the specified format
+func NewFormatter(format string) *Formatter {
+	return &Formatter{
+		format: strings.ToLower(format),
+	}
+}
+
+// FormatSearchResult formats and outputs the search results
+func (f *Formatter) FormatSearchResult(resp *api.SearchResponse) error {
+	switch f.format {
+	case "json":
+		return f.formatJSON(resp)
+	case "table", "":
+		return f.formatTable(resp)
+	default:
+		return fmt.Errorf("지원하지 않는 출력 형식: %s (table, json 중 선택)", f.format)
+	}
+}
+
+// formatJSON outputs results in JSON format
+func (f *Formatter) formatJSON(resp *api.SearchResponse) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(resp)
+}
+
+// formatTable outputs results in table format
+func (f *Formatter) formatTable(resp *api.SearchResponse) error {
+	// Show summary
+	fmt.Printf("총 %d개의 법령을 찾았습니다.\n\n", resp.TotalCount)
+	
+	// If no results, return early
+	if len(resp.Laws) == 0 {
+		fmt.Println("검색 결과가 없습니다.")
+		return nil
+	}
+	
+	// Create simple table output
+	// Print header
+	fmt.Printf("%-5s %-45s %-10s %-15s %-12s\n", "번호", "법령명", "법령구분", "소관부처", "시행일자")
+	fmt.Println(strings.Repeat("-", 100))
+	
+	// Add data rows
+	for i, law := range resp.Laws {
+		// Format dates (YYYYMMDD -> YYYY-MM-DD)
+		effectDate := formatDate(law.EffectDate)
+		
+		// Truncate long names for better display
+		name := truncateString(law.Name, 40)
+		dept := truncateString(law.Department, 13)
+		
+		fmt.Printf("%-5d %-45s %-10s %-15s %-12s\n",
+			i+1,
+			name,
+			law.LawType,
+			dept,
+			effectDate,
+		)
+	}
+	
+	// Show pagination info if there are more results
+	if resp.TotalCount > len(resp.Laws) {
+		currentPage := resp.Page
+		totalPages := (resp.TotalCount + len(resp.Laws) - 1) / len(resp.Laws)
+		fmt.Printf("\n페이지 %d/%d (--page 옵션으로 다른 페이지 조회 가능)\n", currentPage, totalPages)
+	}
+	
+	return nil
+}
+
+// formatDate converts YYYYMMDD to YYYY-MM-DD format
+func formatDate(date string) string {
+	if len(date) != 8 {
+		return date
+	}
+	return fmt.Sprintf("%s-%s-%s", date[:4], date[4:6], date[6:8])
+}
+
+// truncateString truncates a string to maxLen and adds ellipsis if needed
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	// Handle Korean characters properly by using rune slice
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-3]) + "..."
+}

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -1,0 +1,223 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pyhub-kr/pyhub-sejong-cli/internal/api"
+)
+
+func TestNewFormatter(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"table", "table"},
+		{"TABLE", "table"},
+		{"json", "json"},
+		{"JSON", "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			f := NewFormatter(tt.input)
+			if f.format != tt.expected {
+				t.Errorf("NewFormatter(%q).format = %q, want %q", tt.input, f.format, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatSearchResult_JSON(t *testing.T) {
+	// Test data
+	resp := &api.SearchResponse{
+		TotalCount: 2,
+		Page:       1,
+		Laws: []api.LawInfo{
+			{
+				ID:         "001234",
+				Name:       "개인정보 보호법",
+				LawType:    "법률",
+				Department: "개인정보보호위원회",
+				EffectDate: "20200805",
+			},
+			{
+				ID:         "001235",
+				Name:       "개인정보 보호법 시행령",
+				LawType:    "대통령령",
+				Department: "개인정보보호위원회",
+				EffectDate: "20210202",
+			},
+		},
+	}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Format as JSON
+	f := NewFormatter("json")
+	err := f.FormatSearchResult(resp)
+	if err != nil {
+		t.Fatalf("FormatSearchResult failed: %v", err)
+	}
+
+	// Restore stdout and read output
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Parse JSON output
+	var result api.SearchResponse
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v", err)
+	}
+
+	// Verify
+	if result.TotalCount != resp.TotalCount {
+		t.Errorf("TotalCount = %d, want %d", result.TotalCount, resp.TotalCount)
+	}
+	if len(result.Laws) != len(resp.Laws) {
+		t.Errorf("Laws count = %d, want %d", len(result.Laws), len(resp.Laws))
+	}
+}
+
+func TestFormatSearchResult_Table(t *testing.T) {
+	// Test data
+	resp := &api.SearchResponse{
+		TotalCount: 2,
+		Page:       1,
+		Laws: []api.LawInfo{
+			{
+				Name:       "테스트 법령",
+				LawType:    "법률",
+				Department: "테스트부",
+				EffectDate: "20231201",
+			},
+		},
+	}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Format as table
+	f := NewFormatter("table")
+	err := f.FormatSearchResult(resp)
+	if err != nil {
+		t.Fatalf("FormatSearchResult failed: %v", err)
+	}
+
+	// Restore stdout and read output
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify output contains expected elements
+	if !strings.Contains(output, "총 2개의 법령을 찾았습니다") {
+		t.Error("Output should contain total count message")
+	}
+	if !strings.Contains(output, "테스트 법령") {
+		t.Error("Output should contain law name")
+	}
+	if !strings.Contains(output, "2023-12-01") {
+		t.Error("Output should contain formatted date")
+	}
+}
+
+func TestFormatSearchResult_EmptyResult(t *testing.T) {
+	resp := &api.SearchResponse{
+		TotalCount: 0,
+		Page:       1,
+		Laws:       []api.LawInfo{},
+	}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Format as table
+	f := NewFormatter("table")
+	err := f.FormatSearchResult(resp)
+	if err != nil {
+		t.Fatalf("FormatSearchResult failed: %v", err)
+	}
+
+	// Restore stdout and read output
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify
+	if !strings.Contains(output, "검색 결과가 없습니다") {
+		t.Error("Output should contain 'no results' message")
+	}
+}
+
+func TestFormatSearchResult_InvalidFormat(t *testing.T) {
+	resp := &api.SearchResponse{}
+	f := NewFormatter("invalid")
+	err := f.FormatSearchResult(resp)
+	if err == nil {
+		t.Error("Expected error for invalid format")
+	}
+	if !strings.Contains(err.Error(), "지원하지 않는 출력 형식") {
+		t.Errorf("Error message should mention unsupported format, got: %v", err)
+	}
+}
+
+func TestFormatDate(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"20231201", "2023-12-01"},
+		{"20200805", "2020-08-05"},
+		{"2023", "2023"},        // Invalid format, return as-is
+		{"", ""},                 // Empty string
+		{"not-a-date", "not-a-date"}, // Invalid input
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := formatDate(tt.input)
+			if result != tt.expected {
+				t.Errorf("formatDate(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"short", 10, "short"},
+		{"this is a very long string", 10, "this is..."},
+		{"한글테스트입니다", 5, "한글..."},
+		{"", 10, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := truncateString(tt.input, tt.maxLen)
+			if result != tt.expected {
+				t.Errorf("truncateString(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📋 작업 내용

Issue #7: Law 명령어 구현

## ✅ 구현 사항

- `sejong law <검색어>` 명령어 추가
- 테이블/JSON 출력 형식 지원 (`--format` 옵션)
- 페이지네이션 지원 (`--page`, `--size` 옵션)
- API 키 검증 및 친절한 안내 메시지
- 검색 결과 포매팅 및 출력

## 🔧 주요 변경사항

### 1. Law Command (`internal/cmd/law.go`)
- 법령 검색 명령어 구현
- API 키 미설정 시 안내 메시지 표시
- 검색어 검증 및 에러 처리

### 2. Output Formatter (`internal/output/formatter.go`)
- 테이블 형식 출력 (기본)
- JSON 형식 출력 지원
- 날짜 포매팅 (YYYYMMDD → YYYY-MM-DD)
- 긴 텍스트 자동 축약

## 🧪 테스트

- Law 명령어 단위 테스트
- Output formatter 단위 테스트
- 에러 케이스 커버리지

## 💡 사용 예시

```bash
# 기본 검색
sejong law "개인정보 보호법"

# JSON 형식으로 출력
sejong law "도로교통법" --format json

# 페이지네이션
sejong law "민법" --page 2 --size 20

# API 키 없을 때
sejong law "test"
> ❌ API 키가 설정되지 않았습니다.
> 
> 국가법령정보센터 오픈 API 이용을 위해 인증키가 필요합니다.
> 1. 인증키 발급: https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9
> 2. 키 설정: sejong config set law.key <발급받은_인증키>
```

Closes #7

## Sourcery 요약

설정 가능한 출력 형식과 페이지네이션을 지원하는 법령 검색 `law` 명령어를 구현하고, API 키 유효성 검사 및 안내를 포함하며, 출력 형식 개선 및 포괄적인 단위 테스트를 추가합니다.

새로운 기능:
- 쿼리 인수를 사용하여 법령을 검색하는 `law` 명령어 추가
- `--format` 옵션을 통해 테이블 및 JSON 출력 형식 지원
- `--page` 및 `--size` 플래그를 사용하여 페이지네이션 구현
- API 키 유효성 검사 및 누락 시 안내 표시

개선 사항:
- 날짜 변환 및 텍스트 잘림을 통해 법령 데이터 형식 지정

테스트:
- `law` 명령어 인수 및 플래그 처리에 대한 단위 테스트 추가
- JSON, 테이블, 날짜 형식 지정, 잘림 및 오류 사례를 포함하는 출력 포맷터에 대한 테스트 추가

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement the `law` command for statute search with configurable output format and pagination, include API key validation and guidance, enhance output formatting, and add comprehensive unit tests.

New Features:
- Add `law` command to search legal statutes with query argument
- Support table and JSON output formats via `--format` option
- Implement pagination using `--page` and `--size` flags
- Validate API key and display guidance when missing

Enhancements:
- Format statute data with date conversion and text truncation

Tests:
- Add unit tests for the `law` command argument and flag handling
- Add tests for output formatter covering JSON, table, date formatting, truncation, and error cases

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new CLI command to search laws with query validation.
  - Supports output formats: table (default) and JSON, with readable dates, truncation for long text, totals, and pagination hints.
  - New flags: --format, --page, and --size.
  - Improved user guidance and error messages, including handling missing API key.
- Tests
  - Added comprehensive tests for the new command’s argument handling and flags.
  - Added formatter tests covering JSON/table output, empty results, invalid formats, date formatting, and truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->