### PR TITLE
feat: 첫 사용자 온보딩 개선 (#9)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/pyhub-kr/pyhub-sejong-cli
 go 1.24.4
 
 require (
-	github.com/fatih/color v1.15.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
@@ -14,6 +16,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/pyhub-kr/pyhub-sejong-cli/internal/config"
+	"github.com/pyhub-kr/pyhub-sejong-cli/internal/onboarding"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +58,8 @@ var configSetCmd = &cobra.Command{
 			if err := config.SetAPIKey(value); err != nil {
 				return fmt.Errorf("API 키 설정 실패: %w", err)
 			}
-			fmt.Printf("✅ API 키가 성공적으로 설정되었습니다.\n")
+			guide := onboarding.NewGuide()
+			guide.ShowSuccess("API 키가 성공적으로 설정되었습니다")
 			fmt.Printf("설정 파일: %s\n", config.GetConfigPath())
 			return nil
 		}
@@ -68,7 +70,8 @@ var configSetCmd = &cobra.Command{
 			return fmt.Errorf("설정 저장 실패: %w", err)
 		}
 
-		fmt.Printf("✅ 설정이 저장되었습니다: %s = %s\n", key, value)
+		guide := onboarding.NewGuide()
+		guide.ShowSuccess(fmt.Sprintf("설정이 저장되었습니다: %s = %s", key, value))
 		return nil
 	},
 }
@@ -92,10 +95,8 @@ var configGetCmd = &cobra.Command{
 		// Special handling for API key
 		if key == "law.key" {
 			if !config.IsAPIKeySet() {
-				fmt.Println("❌ API 키가 설정되지 않았습니다.")
-				fmt.Println("\n설정 방법:")
-				fmt.Println("1. API 키 발급: https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9")
-				fmt.Println("2. 키 설정: sejong config set law.key <발급받은_인증키>")
+				guide := onboarding.NewGuide()
+				guide.ShowAPIKeySetup()
 				return nil
 			}
 			

--- a/internal/cmd/law.go
+++ b/internal/cmd/law.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/pyhub-kr/pyhub-sejong-cli/internal/api"
+	"github.com/pyhub-kr/pyhub-sejong-cli/internal/onboarding"
 	"github.com/pyhub-kr/pyhub-sejong-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -59,11 +59,8 @@ func runLawCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		// Check if it's an API key error
 		if strings.Contains(err.Error(), "API 키") {
-			fmt.Fprintln(os.Stderr, "❌ API 키가 설정되지 않았습니다.")
-			fmt.Fprintln(os.Stderr)
-			fmt.Fprintln(os.Stderr, "국가법령정보센터 오픈 API 이용을 위해 인증키가 필요합니다.")
-			fmt.Fprintln(os.Stderr, "1. 인증키 발급: https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9")
-			fmt.Fprintln(os.Stderr, "2. 키 설정: sejong config set law.key <발급받은_인증키>")
+			guide := onboarding.NewGuide()
+			guide.ShowAPIKeySetup()
 			return nil // Return nil to avoid printing the error twice
 		}
 		return fmt.Errorf("API 클라이언트 생성 실패: %w", err)
@@ -72,7 +69,8 @@ func runLawCommand(cmd *cobra.Command, args []string) error {
 	// Show searching message
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	if verbose {
-		fmt.Fprintf(os.Stderr, "검색 중... (%s)\n", query)
+		guide := onboarding.NewGuide()
+		guide.ShowSearchProgress(query)
 	}
 	
 	// Create search request

--- a/internal/onboarding/guide.go
+++ b/internal/onboarding/guide.go
@@ -1,0 +1,173 @@
+package onboarding
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/fatih/color"
+)
+
+// Guide provides user onboarding assistance
+type Guide struct {
+	writer io.Writer
+	useColor bool
+}
+
+// NewGuide creates a new onboarding guide
+func NewGuide() *Guide {
+	return &Guide{
+		writer: os.Stderr,
+		useColor: isTerminal() && !isColorDisabled(),
+	}
+}
+
+// NewGuideWithWriter creates a guide with custom writer (for testing)
+func NewGuideWithWriter(w io.Writer, useColor bool) *Guide {
+	return &Guide{
+		writer: w,
+		useColor: useColor,
+	}
+}
+
+// ShowAPIKeySetup displays the API key setup guide
+func (g *Guide) ShowAPIKeySetup() {
+	if g.useColor {
+		g.showColoredAPIKeySetup()
+	} else {
+		g.showPlainAPIKeySetup()
+	}
+}
+
+func (g *Guide) showColoredAPIKeySetup() {
+	// Force color output even when not a terminal (for testing)
+	red := color.New(color.FgRed, color.Bold)
+	yellow := color.New(color.FgYellow)
+	green := color.New(color.FgGreen)
+	cyan := color.New(color.FgCyan)
+	bold := color.New(color.Bold)
+	
+	// Ensure color output is used
+	if g.useColor {
+		color.NoColor = false
+	}
+	
+	// Header
+	red.Fprintln(g.writer, "🔐 API 키 설정이 필요합니다")
+	fmt.Fprintln(g.writer)
+	fmt.Fprintln(g.writer, "국가법령정보센터 오픈 API를 사용하려면 인증키가 필요합니다.")
+	fmt.Fprintln(g.writer)
+	
+	// Steps
+	bold.Fprintln(g.writer, "📋 설정 방법:")
+	fmt.Fprintln(g.writer)
+	
+	// Step 1
+	yellow.Fprint(g.writer, "1️⃣  인증키 발급받기")
+	fmt.Fprintln(g.writer)
+	fmt.Fprint(g.writer, "   → ")
+	cyan.Fprintln(g.writer, "https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9")
+	fmt.Fprintln(g.writer)
+	
+	// Step 2
+	yellow.Fprint(g.writer, "2️⃣  인증키 설정하기")
+	fmt.Fprintln(g.writer)
+	fmt.Fprint(g.writer, "   → ")
+	green.Fprintln(g.writer, "sejong config set law.key <발급받은_인증키>")
+	fmt.Fprintln(g.writer)
+	
+	// Tip
+	fmt.Fprint(g.writer, "💡 ")
+	bold.Fprintln(g.writer, "팁: 위 명령어를 복사하여 사용하세요!")
+	
+	// Platform-specific copy hint
+	g.showCopyHint()
+}
+
+func (g *Guide) showPlainAPIKeySetup() {
+	fmt.Fprintln(g.writer, "❌ API 키 설정이 필요합니다")
+	fmt.Fprintln(g.writer)
+	fmt.Fprintln(g.writer, "국가법령정보센터 오픈 API를 사용하려면 인증키가 필요합니다.")
+	fmt.Fprintln(g.writer)
+	fmt.Fprintln(g.writer, "📋 설정 방법:")
+	fmt.Fprintln(g.writer)
+	fmt.Fprintln(g.writer, "1. 인증키 발급받기")
+	fmt.Fprintln(g.writer, "   → https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9")
+	fmt.Fprintln(g.writer)
+	fmt.Fprintln(g.writer, "2. 인증키 설정하기")
+	fmt.Fprintln(g.writer, "   → sejong config set law.key <발급받은_인증키>")
+	fmt.Fprintln(g.writer)
+	fmt.Fprintln(g.writer, "💡 팁: 위 명령어를 복사하여 사용하세요!")
+	
+	g.showCopyHint()
+}
+
+func (g *Guide) showCopyHint() {
+	switch runtime.GOOS {
+	case "darwin":
+		fmt.Fprintln(g.writer, "   (Mac: Cmd+C로 복사)")
+	case "windows":
+		fmt.Fprintln(g.writer, "   (Windows: Ctrl+C로 복사 또는 마우스 우클릭)")
+	default:
+		fmt.Fprintln(g.writer, "   (Linux: Ctrl+Shift+C로 복사)")
+	}
+}
+
+// ShowSearchProgress displays a search in progress message
+func (g *Guide) ShowSearchProgress(query string) {
+	if g.useColor {
+		spinner := color.New(color.FgCyan)
+		spinner.Fprintf(g.writer, "🔍 검색 중... (%s)\n", query)
+	} else {
+		fmt.Fprintf(g.writer, "검색 중... (%s)\n", query)
+	}
+}
+
+// ShowSuccess displays a success message
+func (g *Guide) ShowSuccess(message string) {
+	if g.useColor {
+		green := color.New(color.FgGreen, color.Bold)
+		green.Fprintf(g.writer, "✅ %s\n", message)
+	} else {
+		fmt.Fprintf(g.writer, "✓ %s\n", message)
+	}
+}
+
+// ShowError displays an error message
+func (g *Guide) ShowError(message string) {
+	if g.useColor {
+		red := color.New(color.FgRed, color.Bold)
+		red.Fprintf(g.writer, "❌ %s\n", message)
+	} else {
+		fmt.Fprintf(g.writer, "✗ %s\n", message)
+	}
+}
+
+// ShowWarning displays a warning message
+func (g *Guide) ShowWarning(message string) {
+	if g.useColor {
+		yellow := color.New(color.FgYellow)
+		yellow.Fprintf(g.writer, "⚠️  %s\n", message)
+	} else {
+		fmt.Fprintf(g.writer, "! %s\n", message)
+	}
+}
+
+// isTerminal checks if output is a terminal
+func isTerminal() bool {
+	fileInfo, _ := os.Stderr.Stat()
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}
+
+// isColorDisabled checks if color output is disabled via environment
+func isColorDisabled() bool {
+	// Check common environment variables that disable color
+	if os.Getenv("NO_COLOR") != "" {
+		return true
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return true
+	}
+	return false
+}

--- a/internal/onboarding/guide.go
+++ b/internal/onboarding/guide.go
@@ -130,7 +130,7 @@ func (g *Guide) ShowSuccess(message string) {
 		green := color.New(color.FgGreen, color.Bold)
 		green.Fprintf(g.writer, "✅ %s\n", message)
 	} else {
-		fmt.Fprintf(g.writer, "✓ %s\n", message)
+		fmt.Fprintf(g.writer, "✅ %s\n", message)
 	}
 }
 
@@ -140,7 +140,7 @@ func (g *Guide) ShowError(message string) {
 		red := color.New(color.FgRed, color.Bold)
 		red.Fprintf(g.writer, "❌ %s\n", message)
 	} else {
-		fmt.Fprintf(g.writer, "✗ %s\n", message)
+		fmt.Fprintf(g.writer, "❌ %s\n", message)
 	}
 }
 
@@ -156,7 +156,12 @@ func (g *Guide) ShowWarning(message string) {
 
 // isTerminal checks if output is a terminal
 func isTerminal() bool {
-	fileInfo, _ := os.Stderr.Stat()
+	fileInfo, err := os.Stderr.Stat()
+	if err != nil {
+		// If we can't stat stderr, assume it's not a terminal
+		// This is safe because we'll just disable colors
+		return false
+	}
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
 }
 

--- a/internal/onboarding/guide_test.go
+++ b/internal/onboarding/guide_test.go
@@ -1,0 +1,171 @@
+package onboarding
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNewGuide(t *testing.T) {
+	guide := NewGuide()
+	if guide == nil {
+		t.Error("Expected guide to be created")
+	}
+	if guide.writer == nil {
+		t.Error("Expected writer to be set")
+	}
+}
+
+func TestGuide_ShowAPIKeySetup_Plain(t *testing.T) {
+	var buf bytes.Buffer
+	guide := NewGuideWithWriter(&buf, false)
+	
+	guide.ShowAPIKeySetup()
+	
+	output := buf.String()
+	
+	// Check for required elements
+	expectedStrings := []string{
+		"API 키 설정이 필요합니다",
+		"국가법령정보센터 오픈 API",
+		"설정 방법:",
+		"인증키 발급받기",
+		"https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9",
+		"인증키 설정하기",
+		"sejong config set law.key",
+		"팁: 위 명령어를 복사하여 사용하세요",
+	}
+	
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Output should contain %q", expected)
+		}
+	}
+}
+
+func TestGuide_ShowAPIKeySetup_Colored(t *testing.T) {
+	var buf bytes.Buffer
+	guide := NewGuideWithWriter(&buf, true)
+	
+	guide.ShowAPIKeySetup()
+	
+	output := buf.String()
+	
+	// Check for required content (color codes will be present but we check the text)
+	expectedStrings := []string{
+		"API 키 설정이 필요합니다",
+		"설정 방법:",
+		"인증키 발급받기",
+		"인증키 설정하기",
+	}
+	
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Output should contain %q", expected)
+		}
+	}
+	
+	// Check that ANSI color codes are present
+	if !strings.Contains(output, "\x1b[") {
+		t.Error("Colored output should contain ANSI escape codes")
+	}
+}
+
+func TestGuide_ShowSearchProgress(t *testing.T) {
+	tests := []struct {
+		name     string
+		useColor bool
+		query    string
+		expected string
+	}{
+		{
+			name:     "Plain text",
+			useColor: false,
+			query:    "test query",
+			expected: "검색 중... (test query)",
+		},
+		{
+			name:     "Colored text",
+			useColor: true,
+			query:    "test query",
+			expected: "검색 중... (test query)",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			guide := NewGuideWithWriter(&buf, tt.useColor)
+			
+			guide.ShowSearchProgress(tt.query)
+			
+			output := buf.String()
+			if !strings.Contains(output, tt.expected) {
+				t.Errorf("Output should contain %q, got %q", tt.expected, output)
+			}
+		})
+	}
+}
+
+func TestGuide_ShowSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	guide := NewGuideWithWriter(&buf, false)
+	
+	guide.ShowSuccess("Operation completed")
+	
+	output := buf.String()
+	if !strings.Contains(output, "Operation completed") {
+		t.Errorf("Output should contain success message")
+	}
+	if !strings.Contains(output, "✓") {
+		t.Errorf("Output should contain success indicator")
+	}
+}
+
+func TestGuide_ShowError(t *testing.T) {
+	var buf bytes.Buffer
+	guide := NewGuideWithWriter(&buf, false)
+	
+	guide.ShowError("Operation failed")
+	
+	output := buf.String()
+	if !strings.Contains(output, "Operation failed") {
+		t.Errorf("Output should contain error message")
+	}
+	if !strings.Contains(output, "✗") {
+		t.Errorf("Output should contain error indicator")
+	}
+}
+
+func TestGuide_ShowWarning(t *testing.T) {
+	var buf bytes.Buffer
+	guide := NewGuideWithWriter(&buf, false)
+	
+	guide.ShowWarning("This is a warning")
+	
+	output := buf.String()
+	if !strings.Contains(output, "This is a warning") {
+		t.Errorf("Output should contain warning message")
+	}
+	if !strings.Contains(output, "!") {
+		t.Errorf("Output should contain warning indicator")
+	}
+}
+
+func TestGuide_PlatformSpecificCopyHint(t *testing.T) {
+	var buf bytes.Buffer
+	guide := NewGuideWithWriter(&buf, false)
+	
+	guide.ShowAPIKeySetup()
+	
+	output := buf.String()
+	
+	// Should contain at least one of the platform-specific copy hints
+	hasCopyHint := strings.Contains(output, "Cmd+C") || 
+		strings.Contains(output, "Ctrl+C") ||
+		strings.Contains(output, "Ctrl+Shift+C")
+	
+	if !hasCopyHint {
+		t.Error("Output should contain platform-specific copy hint")
+	}
+}

--- a/internal/onboarding/guide_test.go
+++ b/internal/onboarding/guide_test.go
@@ -117,7 +117,7 @@ func TestGuide_ShowSuccess(t *testing.T) {
 	if !strings.Contains(output, "Operation completed") {
 		t.Errorf("Output should contain success message")
 	}
-	if !strings.Contains(output, "✓") {
+	if !strings.Contains(output, "✅") {
 		t.Errorf("Output should contain success indicator")
 	}
 }
@@ -132,8 +132,27 @@ func TestGuide_ShowError(t *testing.T) {
 	if !strings.Contains(output, "Operation failed") {
 		t.Errorf("Output should contain error message")
 	}
-	if !strings.Contains(output, "✗") {
+	if !strings.Contains(output, "❌") {
 		t.Errorf("Output should contain error indicator")
+	}
+}
+
+func TestGuide_ShowError_Colored(t *testing.T) {
+	var buf bytes.Buffer
+	guide := NewGuideWithWriter(&buf, true)
+	
+	guide.ShowError("Operation failed")
+	
+	output := buf.String()
+	if !strings.Contains(output, "Operation failed") {
+		t.Errorf("Output should contain error message")
+	}
+	if !strings.Contains(output, "❌") {
+		t.Errorf("Output should contain error indicator")
+	}
+	// Check that ANSI color codes are present
+	if !strings.Contains(output, "\x1b[") {
+		t.Error("Colored output should contain ANSI escape codes")
 	}
 }
 


### PR DESCRIPTION
## 📋 작업 내용

Issue #9: 첫 사용자 온보딩 개선

## ✅ 구현 사항

### 1. 색상 출력 지원
- fatih/color 라이브러리 추가
- 터미널 색상 자동 감지
- NO_COLOR 환경 변수 지원

### 2. API 키 설정 가이드 개선
- 🔐 이모지 사용으로 시각적 강조
- 색상으로 단계별 구분 (빨강: 헤더, 노랑: 단계, 녹색: 명령어, 청록: URL)
- 1️⃣ 2️⃣ 번호 이모지로 단계 구분
- 💡 팁 섹션 추가

### 3. 플랫폼별 복사 힌트
- Mac: Cmd+C로 복사
- Windows: Ctrl+C로 복사 또는 마우스 우클릭
- Linux: Ctrl+Shift+C로 복사

### 4. 메시지 개선
- ✅ 성공 메시지 (녹색)
- ❌ 에러 메시지 (빨강)
- ⚠️ 경고 메시지 (노랑)
- 🔍 검색 진행 표시 (청록)

## 🧪 테스트

- 온보딩 가이드 모듈 단위 테스트
- 색상/일반 텍스트 모드 테스트
- 플랫폼별 복사 힌트 테스트

## 📸 실행 예시

### API 키 미설정 시
```
$ sejong law "test"
🔐 API 키 설정이 필요합니다

국가법령정보센터 오픈 API를 사용하려면 인증키가 필요합니다.

📋 설정 방법:

1️⃣  인증키 발급받기
   → https://www.law.go.kr/LSW/opn/prvsn/opnPrvsnInfoP.do?mode=9

2️⃣  인증키 설정하기
   → sejong config set law.key <발급받은_인증키>

💡 팁: 위 명령어를 복사하여 사용하세요!
   (Mac: Cmd+C로 복사)
```

### API 키 설정 시
```
$ sejong config set law.key TEST_KEY
✅ API 키가 성공적으로 설정되었습니다
설정 파일: /Users/username/.sejong/config.yaml
```

### 검색 진행 표시 (--verbose)
```
$ sejong law "개인정보" --verbose
🔍 검색 중... (개인정보)
```

Closes #9

## Sourcery 요약

CLI를 위한 중앙 집중식 온보딩 가이드를 구현하여 API 키 설정, 명령어 성공/오류/경고, 검색 진행 상황에 대해 색상 및 이모지가 적용된 메시지를 제공합니다. 이를 config 및 law 명령어에 통합하고, 플랫폼별 복사 힌트를 추가하며, 색상/터미널 의존성을 업그레이드합니다.

새로운 기능:
- API 키 설정 지침, 검색 진행 상황, 그리고 형식화된 성공/오류/경고 메시지를 표시하는 메서드를 포함하는 `internal/onboarding.Guide` 추가

개선 사항:
- 터미널 및 `NO_COLOR` 환경 변수를 감지하여 `fatih/color` 출력을 조건부로 사용
- 온보딩 메시지에서 플랫폼별 복사 힌트 제공
- `fatih/color`를 v1.18.0으로, `go-isatty`를 v0.0.20으로 업그레이드

테스트:
- `onboarding.Guide` 메서드 및 출력 형식을 다루는 유닛 테스트 추가

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a centralized onboarding guide for the CLI to deliver colored, emoji-enhanced messages for API key setup, command success/error/warning, and search progress; integrate it into config and law commands, add platform-specific copy hints, and upgrade color/terminal dependencies.

New Features:
- Add internal/onboarding.Guide with methods for showing API key setup instructions, search progress, and formatted success/error/warning messages

Enhancements:
- Detect terminal and NO_COLOR env var to conditionally use fatih/color output
- Provide platform-specific copy hints in onboarding messages
- Upgrade fatih/color to v1.18.0 and go-isatty to v0.0.20

Tests:
- Add unit tests covering onboarding.Guide methods and output formats

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced an onboarding guide that provides step-by-step API key setup with colored or plain output, platform-specific copy hints, and Korean-language guidance.
  * Unified messaging for success, error, warning, and search progress, including improved verbose progress output.

* Tests
  * Added comprehensive tests covering onboarding messages in both colored and plain modes, success/error/warning indicators, search progress, and platform-specific hints.

* Chores
  * Updated indirect dependencies to improve compatibility and terminal color handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->